### PR TITLE
Implement Offline Access and Refresh Token Handling for Google OAuth

### DIFF
--- a/Sources/ImperialCore/Routing/FederatedServiceRouter.swift
+++ b/Sources/ImperialCore/Routing/FederatedServiceRouter.swift
@@ -108,6 +108,9 @@ extension FederatedServiceRouter {
             .flatMap { buffer in
                 return request.client.post(url, headers: self.callbackHeaders) { $0.body = buffer }
             }.flatMapThrowing { response in
+                if let refreshToken = try? response.content.get(String.self, at: ["refresh_token"]), !refreshToken.isEmpty {
+                    request.session.setRefreshToken(refreshToken)
+                }
                 return try response.content.get(String.self, at: ["access_token"])
             }
     }

--- a/Sources/ImperialGoogle/Standard/GoogleAccessType.swift
+++ b/Sources/ImperialGoogle/Standard/GoogleAccessType.swift
@@ -1,0 +1,4 @@
+public enum GoogleAccessType: String {
+    case offline = "offline"
+    case online = "online"
+}

--- a/Sources/ImperialGoogle/Standard/GoogleOffline.swift
+++ b/Sources/ImperialGoogle/Standard/GoogleOffline.swift
@@ -1,7 +1,7 @@
 @_exported import ImperialCore
 import Vapor
 
-public class Google: FederatedService {
+public class GoogleOffline: FederatedService {
     public var tokens: FederatedServiceTokens
     public var router: FederatedServiceRouter
     
@@ -14,7 +14,7 @@ public class Google: FederatedService {
         scope: [String] = [],
         completion: @escaping (Request, String) throws -> (EventLoopFuture<ResponseEncodable>)
     ) throws {
-        self.router = try GoogleRouter(callback: callback, completion: completion, accessType: .online)
+        self.router = try GoogleRouter(callback: callback, completion: completion, accessType: .offline)
         self.tokens = self.router.tokens
         
         self.router.scope = scope

--- a/Sources/ImperialGoogle/Standard/GoogleRouter.swift
+++ b/Sources/ImperialGoogle/Standard/GoogleRouter.swift
@@ -42,6 +42,10 @@ public class GoogleRouter: FederatedServiceRouter {
             codeResponseTypeItem,
             accessTypeItem
         ]
+
+        if accessType == .offline {
+            components.queryItems?.append(promptItem)
+        }
         
         guard let url = components.url else {
             throw Abort(.internalServerError)
@@ -59,6 +63,10 @@ public class GoogleRouter: FederatedServiceRouter {
 
     public var accessTypeItem: URLQueryItem {
         .init(name: "access_type", value: accessType.rawValue)
+    }
+
+    public var promptItem: URLQueryItem {
+        .init(name: "prompt", value: "consent")
     }
 
 }

--- a/Sources/ImperialGoogle/Standard/GoogleRouter.swift
+++ b/Sources/ImperialGoogle/Standard/GoogleRouter.swift
@@ -8,6 +8,7 @@ public class GoogleRouter: FederatedServiceRouter {
     public let callbackURL: String
     public let accessTokenURL: String = "https://www.googleapis.com/oauth2/v4/token"
     public let service: OAuthService = .google
+    public var accessType: GoogleAccessType = .online
     public let callbackHeaders: HTTPHeaders = {
         var headers = HTTPHeaders()
         headers.contentType = .urlEncodedForm
@@ -19,6 +20,15 @@ public class GoogleRouter: FederatedServiceRouter {
         self.callbackURL = callback
         self.callbackCompletion = completion
     }
+
+    public convenience init(
+        callback: String, 
+        completion: @escaping (Request, String) throws -> (EventLoopFuture<ResponseEncodable>), 
+        accessType: GoogleAccessType
+    ) throws {
+        try self.init(callback: callback, completion: completion)
+        self.accessType = accessType
+    }
     
     public func authURL(_ request: Request) throws -> String {        
         var components = URLComponents()
@@ -29,7 +39,8 @@ public class GoogleRouter: FederatedServiceRouter {
             clientIDItem,
             redirectURIItem,
             scopeItem,
-            codeResponseTypeItem
+            codeResponseTypeItem,
+            accessTypeItem
         ]
         
         guard let url = components.url else {
@@ -44,6 +55,10 @@ public class GoogleRouter: FederatedServiceRouter {
                            clientId: tokens.clientID,
                            clientSecret: tokens.clientSecret,
                            redirectURI: callbackURL)
+    }
+
+    public var accessTypeItem: URLQueryItem {
+        .init(name: "access_type", value: accessType.rawValue)
     }
 
 }

--- a/Sources/ImperialGoogle/Standard/GoogleRouter.swift
+++ b/Sources/ImperialGoogle/Standard/GoogleRouter.swift
@@ -34,7 +34,7 @@ public class GoogleRouter: FederatedServiceRouter {
         var components = URLComponents()
         components.scheme = "https"
         components.host = "accounts.google.com"
-        components.path = "/o/oauth2/auth"
+        components.path = "/o/oauth2/v2/auth"
         components.queryItems = [
             clientIDItem,
             redirectURIItem,


### PR DESCRIPTION
This PR introduces several enhancements and updates to the Google OAuth integration:

- **Add Option to Use Offline `access_type` for Google OAuth**
  - Implemented the ability to request offline access, allowing the application to receive refresh tokens.
  
- **Set Refresh Token After Token is Received**
  - Ensured that the refresh token is properly stored and managed once received from Google.
  
- **Add `prompt=consent` Parameter if `access_type` is Offline**
  - Included the `prompt=consent` parameter in the OAuth URL to ensure that the user is prompted for consent when offline access is requested.
  
- **Update Google OAuth URL**
  - Updated the Google OAuth URL to reflect the necessary changes for offline access and refresh token handling.

These changes enhance the OAuth flow by enabling the application to maintain long-term access to the user's Google account, improving user experience and reducing the need for repeated authorizations.

### Commits
- **Add option to use offline access_type for Google**
  - Implemented offline access type to request refresh tokens.
- **Set refresh token after token received**
  - Added logic to store and manage the refresh token upon receipt.
- **Add prompt=consent if access_type is offline**
  - Updated OAuth URL to include prompt=consent for offline access requests.
- **Update Google OAuth URL**
  - Adjusted the OAuth URL to incorporate changes for offline access and refresh tokens.

### Additional Notes
These updates are crucial for applications that need prolonged access to user data without requiring frequent re-authentication, thereby enhancing the overall user experience and reliability of the service.